### PR TITLE
Avoid clobbering db on `no space left on device`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: agkozak
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: [ "https://www.paypal.me/agkozak" ]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- Unreleased
+    + `--add` has been made to work with relative paths and has been documented for the user.
 - October 14, 2021
     + Completions were being sorted alphabetically, rather than by rank; this error has been fixed.
 - September 25, 2021
@@ -226,6 +228,7 @@ to install `zsh-z`.
 
 ## Command Line Options
 
+- `--add` Add a directory to the database
 - `-c`    Only match subdirectories of the current directory
 - `-e`    Echo the best match without going to it
 - `-h`    Display help

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- July 27, 2021
+    + Internal escaping of path names now works with older versions of ZSH.
+    + ZSH-z now detects and discards any incomplete or incorrectly formattted database entries.
 - July 10, 2021
     + Setting `ZSHZ_TRAILING_SLASH=1` makes it so that a search pattern ending in `/` can match the end of a path; e.g. `z foo/` can match `/path/to/foo`.
 - June 25, 2021

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 
 <details>
     <summary>Here are the latest features and updates.</summary>
-
+- May 7, 2021
+  + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when changing directories.
+  + Better escaping of path names to deal paths containing the characters ``\`()[]``.
 - February 15, 2021
   + Ranks are displayed the way `rupa/z` now displays them, i.e. as large integers. This should help ZSH-z to integrate with other tools.
 - January 31, 2021
@@ -199,6 +201,7 @@ ZSH-z has environment variables (they all begin with `ZSHZ_`) that change its be
 * `ZSHZ_CMD` changes the command name (default: `z`)
 * `ZSHZ_COMPLETION` can be `'frecent'` (default) or `'legacy'`, depending on whether you want your completion results sorted according to frecency or simply sorted alphabetically
 * `ZSHZ_DATA` changes the database file (default: `~/.z`)
+* `ZSHZ_ECHO` displays the new path name when changing directories (default: `0`)
 * `ZSHZ_EXCLUDE_DIRS` is an array of directories to keep out of the database (default: empty)
 * `ZSHZ_KEEP_DIRS` is an array of directories that should not be removed from the database, even if they are not currently available (useful when a drive is not always mounted) (default: empty)
 * `ZSHZ_MAX_SCORE` is the maximum combined score the database entries can have before they begin to age and potentially drop out of the database (default: 9000)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- August 27, 2021
+    + Using `print -v ... -f` instead of `print -v` to work around longstanding bug in ZSH involving `print -v` and multibyte strings.
 - August 13, 2021
     + Fixed the explanation string printed during completion so that it may be formatted with `zstyle`.
     + ZSH-z now declares `ZSHZ_EXCLUDE_DIRS` as an array with unique elements so that you do not have to.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Simply add
 
     zcomet load agkozak/zsh-z
 
-to your `.zshrc` (below where you source `zcomet.zsh` and above where you load `compinit`).
+to your `.zshrc` (below where you source `zcomet.zsh` and above where you run `zcomet compinit`).
 
 ### For [zgen](https://github.com/tarjoilija/zgen) users
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- July 29, 2021
+    + Temporarily disabling use of `print -v`, which seems to be mangling CJK multibyte strings.
 - July 27, 2021
     + Internal escaping of path names now works with older versions of ZSH.
     + ZSH-z now detects and discards any incomplete or incorrectly formattted database entries.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Then run
 
 and restart your shell.
 
-### For [Zinit](https://github.com/zdharma/zinit) (formerly `zplugin`) users
+### For Zinit (formerly `zplugin`) users
 
 Add the line
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`.
 
 ZSH-z's database format is identical to that of `rupa/z`. You may switch freely between the two tools (I still use `rupa/z` for `bash`). `fasd` also uses that database format, but it stores it by default in `~/.fasd`, so you will have to `cp ~/.fasd ~/.z` if you want to use your old directory history.
 
-If you are coming to ZSH-z (or even to the original `rupa/z`, for that matter) from `autojump`, try using my [`jumpstart-z`](https://github.com/agkozak/jumpstart-z/blob/master/jumpstart-z) tool to convert your old database to the ZSH-z format.
+If you are coming to ZSH-z (or even to the original `rupa/z`, for that matter) from `autojump`, try using my [`jumpstart-z`](https://github.com/agkozak/jumpstart-z/blob/master/jumpstart-z) tool to convert your old database to the ZSH-z format, or simply run
+
+    awk -F "\t" '{printf("%s|%0.f|%s\n", $2, $1, '"$(date +%s)"')}' < /path/to/autojump.txt > ~/.z
 
 ## `COMPLETE_ALIASES`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 - [Settings](#settings)
 - [Case Sensitivity](#case-sensitivity)
 - [`ZSHZ_UNCOMMON`](#zshz_uncommon)
-- [Making `--add` work for you](#making-add-work-for-you)
+- [Making `--add` work for you](#making---add-work-for-you)
 - [Other Improvements and Fixes](#other-improvements-and-fixes)
 - [Migrating from Other Tools](#migrating-from-other-tools)
 - [`COMPLETE_ALIASES`](#complete_aliases)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
     <summary>Here are the latest features and updates.</summary>
 
 - May 7, 2021
-  + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when changing directories.
+  + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when you change directories.
   + Better escaping of path names to deal paths containing the characters ``\`()[]``.
 - February 15, 2021
   + Ranks are displayed the way `rupa/z` now displays them, i.e. as large integers. This should help ZSH-z to integrate with other tools.
@@ -172,6 +172,14 @@ to your `.zshrc`.
 
 `zsh-z` supports `zinit`'s `unload` feature; just run `zinit unload agkozak/zshz` to restore the shell to its state before `zsh-z` was loaded.
 
+### For [Znap](https://github.com/marlonrichert/zsh-snap) users
+
+Add the line
+
+    znap source agkozak/zsh-z
+
+somewhere below the line where you `source` Znap itself.
+
 ### For [zplug](https://github.com/zplug/zplug) users
 
 Add the line
@@ -208,6 +216,7 @@ ZSH-z has environment variables (they all begin with `ZSHZ_`) that change its be
 * `ZSHZ_MAX_SCORE` is the maximum combined score the database entries can have before they begin to age and potentially drop out of the database (default: 9000)
 * `ZSHZ_NO_RESOLVE_SYMLINKS` prevents symlink resolution (default: `0`)
 * `ZSHZ_OWNER` allows usage when in `sudo -s` mode (default: empty)
+* `ZSHZ_TILDE` displays the name of the `HOME` directory as a `~` (default: `0`)
 
 ## Case sensitivity
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 
 - August 13, 2021
     + Fixed the explanation string printed during completion so that it may be formatted with `zstyle`.
+    + ZSH-z now declares `ZSHZ_EXCLUDE_DIRS` as an array with unique elements so that you do not have to.
 - July 29, 2021
     + Temporarily disabling use of `print -v`, which seems to be mangling CJK multibyte strings.
 - July 27, 2021

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
     <summary>Here are the latest features and updates.</summary>
 
 - Unreleased
+    + A bug was fixed which was preventing ranks from being incremented.
     + `--add` has been made to work with relative paths and has been documented for the user.
 - October 14, 2021
     + Completions were being sorted alphabetically, rather than by rank; this error has been fixed.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- October 14, 2021
+    + Completions were being sorted alphabetically, rather than by rank; this error has been fixed.
 - September 25, 2021
     + Orthographical change: "Zsh," not "ZSH."
 - September 23, 2021

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 
 <details>
     <summary>Here are the latest features and updates.</summary>
+
 - May 7, 2021
   + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when changing directories.
   + Better escaping of path names to deal paths containing the characters ``\`()[]``.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# ZSH-z
+# Zsh-z
 
 [![MIT License](img/mit_license.svg)](https://opensource.org/licenses/MIT)
-![ZSH version 4.3.11 and higher](img/zsh_4.3.11_plus.svg)
+![Zsh version 4.3.11 and higher](img/zsh_4.3.11_plus.svg)
 [![GitHub stars](https://img.shields.io/github/stars/agkozak/zsh-z.svg)](https://github.com/agkozak/zsh-z/stargazers)
 
-![ZSH-z demo](img/demo.gif)
+![Zsh-z demo](img/demo.gif)
 
-ZSH-z is a command line tool that allows you to jump quickly to directories that you have visited frequently in the past, or recently -- but most often a combination of the two (a concept known as ["frecency"](https://en.wikipedia.org/wiki/Frecency)). It works by keeping track of when you go to directories and how much time you spend in them. It is then in the position to guess where you want to go when you type a partial string, e.g., `z src` might take you to `~/src/zsh`. `z zsh` might also get you there, and `z c/z` might prove to be even more specific -- it all depends on your habits and how much time you have been using ZSH-z to build up a database. After using ZSH-z for a little while, you will get to where you want to be by typing considerably less than you would need if you were using `cd`.
+Zsh-z is a command line tool that allows you to jump quickly to directories that you have visited frequently in the past, or recently -- but most often a combination of the two (a concept known as ["frecency"](https://en.wikipedia.org/wiki/Frecency)). It works by keeping track of when you go to directories and how much time you spend in them. It is then in the position to guess where you want to go when you type a partial string, e.g., `z src` might take you to `~/src/zsh`. `z zsh` might also get you there, and `z c/z` might prove to be even more specific -- it all depends on your habits and how much time you have been using Zsh-z to build up a database. After using Zsh-z for a little while, you will get to where you want to be by typing considerably less than you would need if you were using `cd`.
 
-ZSH-z is a native ZSH port of [rupa/z](https://github.com/rupa/z), a tool written for `bash` and ZSH that uses embedded `awk` scripts to do the heavy lifting. It was quite possibly my most used command line tool for a couple of years. I decided to translate it, `awk` parts and all, into pure ZSH script, to see if by eliminating calls to external tools (`awk`, `sort`, `date`, `sed`, `mv`, `rm`, and `chown`) and reducing forking through subshells I could make it faster. The performance increase is impressive, particularly on systems where forking is slow, such as Cygwin, MSYS2, and WSL. I have found that, in those environments, switching directories using ZSH-z can be over 100% faster than it is using `rupa/z`.
+Zsh-z is a native Zsh port of [rupa/z](https://github.com/rupa/z), a tool written for `bash` and Zsh that uses embedded `awk` scripts to do the heavy lifting. It was quite possibly my most used command line tool for a couple of years. I decided to translate it, `awk` parts and all, into pure Zsh script, to see if by eliminating calls to external tools (`awk`, `sort`, `date`, `sed`, `mv`, `rm`, and `chown`) and reducing forking through subshells I could make it faster. The performance increase is impressive, particularly on systems where forking is slow, such as Cygwin, MSYS2, and WSL. I have found that, in those environments, switching directories using Zsh-z can be over 100% faster than it is using `rupa/z`.
 
-There is a noteworthy stability increase as well. Race conditions have always been a problem with `rupa/z`, and users of that utility will occasionally lose their `.z` databases. By having ZSH-z only use ZSH (`rupa/z` uses a hybrid shell code that works on `bash` as well), I have been able to implement a `zsh/system`-based file-locking mechanism similar to [the one @mafredri once proposed for `rupa/z`](https://github.com/rupa/z/pull/199). It is now nearly impossible to crash the database, even through extreme testing.
+There is a noteworthy stability increase as well. Race conditions have always been a problem with `rupa/z`, and users of that utility will occasionally lose their `.z` databases. By having Zsh-z only use Zsh (`rupa/z` uses a hybrid shell code that works on `bash` as well), I have been able to implement a `zsh/system`-based file-locking mechanism similar to [the one @mafredri once proposed for `rupa/z`](https://github.com/rupa/z/pull/199). It is now nearly impossible to crash the database, even through extreme testing.
 
-There are other, smaller improvements which I try to document in [Improvements and Fixes](#improvements-and-fixes). These include the new default behavior of sorting your tab completions by frecency rather than just letting ZSH sort the raw results alphabetically (a behavior which can be restored if you like it -- [see below](#settings)).
+There are other, smaller improvements which I try to document in [Improvements and Fixes](#improvements-and-fixes). These include the new default behavior of sorting your tab completions by frecency rather than just letting Zsh sort the raw results alphabetically (a behavior which can be restored if you like it -- [see below](#settings)).
 
-ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same database (`~/.z`), so you can go on using `rupa/z` when you launch `bash`.
+Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same database (`~/.z`), so you can go on using `rupa/z` when you launch `bash`.
 
 ## Table of Contents
 - [News](#news)
@@ -33,47 +33,49 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- Unreleased
+    + Orthographical change: "Zsh," not "ZSH."
 - September 23, 2021
     + `z -xR` will now remove a directory *and its subdirectories* from the database.
     + `z -x` and `z -xR` can now take an argument; without one, `PWD` is assumed.
 - September 7, 2021
     + Fixed the unload function so that it removes the `$ZSHZ_CMD` alias (default: `z`).
 - August 27, 2021
-    + Using `print -v ... -f` instead of `print -v` to work around longstanding bug in ZSH involving `print -v` and multibyte strings.
+    + Using `print -v ... -f` instead of `print -v` to work around longstanding bug in Zsh involving `print -v` and multibyte strings.
 - August 13, 2021
     + Fixed the explanation string printed during completion so that it may be formatted with `zstyle`.
-    + ZSH-z now declares `ZSHZ_EXCLUDE_DIRS` as an array with unique elements so that you do not have to.
+    + Zsh-z now declares `ZSHZ_EXCLUDE_DIRS` as an array with unique elements so that you do not have to.
 - July 29, 2021
     + Temporarily disabling use of `print -v`, which seems to be mangling CJK multibyte strings.
 - July 27, 2021
     + Internal escaping of path names now works with older versions of ZSH.
-    + ZSH-z now detects and discards any incomplete or incorrectly formattted database entries.
+    + Zsh-z now detects and discards any incomplete or incorrectly formattted database entries.
 - July 10, 2021
     + Setting `ZSHZ_TRAILING_SLASH=1` makes it so that a search pattern ending in `/` can match the end of a path; e.g. `z foo/` can match `/path/to/foo`.
 - June 25, 2021
     + Setting `ZSHZ_TILDE=1` displays the `HOME` directory as `~`.
 - May 7, 2021
-    + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when you change directories.
+    + Setting `ZSHZ_ECHO=1` will cause Zsh-z to display the new path when you change directories.
     + Better escaping of path names to deal paths containing the characters ``\`()[]``.
 - February 15, 2021
-    + Ranks are displayed the way `rupa/z` now displays them, i.e. as large integers. This should help ZSH-z to integrate with other tools.
+    + Ranks are displayed the way `rupa/z` now displays them, i.e. as large integers. This should help Zsh-z to integrate with other tools.
 - January 31, 2021
-    + ZSH-z is now efficient enough that, on MSYS2 and Cygwin, it is faster to run it in the foreground than it is to fork a subshell for it.
+    + Zsh-z is now efficient enough that, on MSYS2 and Cygwin, it is faster to run it in the foreground than it is to fork a subshell for it.
     + `_zshz_precmd` simply returns if `PWD` is `HOME` or in `ZSH_EXCLUDE_DIRS`, rather than waiting for `zshz` to do that.
 - January 17, 2021
     + Made sure that the `PUSHD_IGNORE_DUPS` option is respected.
 - January 14, 2021
     + The `z -h` help text now breaks at spaces.
-    + `z -l` was not working for ZSH version < 5.
+    + `z -l` was not working for Zsh version < 5.
 - January 11, 2021
     + Major refactoring of the code.
     + `z -lr` and `z -lt` work as expected.
     + `EXTENDED_GLOB` has been disabled within the plugin to accomodate old-fashioned Windows directories with names such as `Progra~1`.
     + Removed `zshelldoc` documentation.
 - January 6, 2021
-    + I have corrected the frecency routine so that it matches `rupa/z`'s math, but for the present, ZSH-z will continue to display ranks as 1/10000th of what they are in `rupa/z` -- [they had to multiply theirs by 10000](https://github.com/rupa/z/commit/f1f113d9bae9effaef6b1e15853b5eeb445e0712) to work around `bash`'s inadequacies at dealing with decimal fractions.
+    + I have corrected the frecency routine so that it matches `rupa/z`'s math, but for the present, Zsh-z will continue to display ranks as 1/10000th of what they are in `rupa/z` -- [they had to multiply theirs by 10000](https://github.com/rupa/z/commit/f1f113d9bae9effaef6b1e15853b5eeb445e0712) to work around `bash`'s inadequacies at dealing with decimal fractions.
 - January 5, 2021
-    + If you try `z foo`, and `foo` is not in the database but `${PWD}/foo` is a valid directory, ZSH-z will `cd` to it.
+    + If you try `z foo`, and `foo` is not in the database but `${PWD}/foo` is a valid directory, Zsh-z will `cd` to it.
 - December 22, 2020
     + `ZSHZ_CASE`: when set to `ignore`, pattern matching is case-insensitive; when set to `smart`, patterns are matched case-insensitively when they are all lowercase and case-sensitively when they have uppercase characters in them (a behavior very much like Vim's `smartcase` setting).
     + `ZSHZ_KEEP_DIRS` is an array of directory names that should not be removed from the database, even if they are not currently available (useful when a drive is not always mounted).
@@ -233,7 +235,7 @@ to install `zsh-z`.
 
 # Settings
 
-ZSH-z has environment variables (they all begin with `ZSHZ_`) that change its behavior if you set them; you can also keep your old ones if you have been using `rupa/z` (they begin with `_Z_`).
+Zsh-z has environment variables (they all begin with `ZSHZ_`) that change its behavior if you set them; you can also keep your old ones if you have been using `rupa/z` (they begin with `_Z_`).
 
 * `ZSHZ_CMD` changes the command name (default: `z`)
 * `ZSHZ_COMPLETION` can be `'frecent'` (default) or `'legacy'`, depending on whether you want your completion results sorted according to frecency or simply sorted alphabetically
@@ -250,7 +252,7 @@ ZSH-z has environment variables (they all begin with `ZSHZ_`) that change its be
 
 ## Case sensitivity
 
-The default behavior of ZSH-z is to try to find a case-sensitive match. If there is none, then ZSH-z tries to find a case-insensitive match.
+The default behavior of Zsh-z is to try to find a case-sensitive match. If there is none, then Zsh-z tries to find a case-insensitive match.
 
 Some users prefer simple case-insensitivity; this behavior can be enabled by setting
 
@@ -262,13 +264,13 @@ If you like Vim's `smartcase` setting, where lowercase patterns are case-insensi
 
 ## `ZSHZ_UNCOMMON`
 
-A common complaint about the default behavior of `rupa/z` and ZSH-z involves "common prefixes." If you type `z code` and the best matches, in increasing order, are
+A common complaint about the default behavior of `rupa/z` and Zsh-z involves "common prefixes." If you type `z code` and the best matches, in increasing order, are
 
     /home/me/code/foo
     /home/me/code/bar
     /home/me/code/bat
 
-ZSH-z will see that all possible matches share a common prefix and will send you to that directory -- `/home/me/code` -- which is often a desirable result. But if the possible matches are
+Zsh-z will see that all possible matches share a common prefix and will send you to that directory -- `/home/me/code` -- which is often a desirable result. But if the possible matches are
 
     /home/me/.vscode/foo
     /home/me/code/foo
@@ -277,13 +279,13 @@ ZSH-z will see that all possible matches share a common prefix and will send you
 
 then there is no common prefix. In this case, `z code` will simply send you to the highest-ranking match, `/home/me/code/bat`.
 
-You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`. If you do that, ZSH-z will not jump to a common prefix, even if one exists. Instead, it chooses the highest-ranking match -- but it drops any subdirectories that do not include the search term. So if you type `z bat` and `/home/me/code/bat` is the best match, that is exactly where you will end up. If, however, you had typed `z code` and the best match was also `/home/me/code/bat`, you would have ended up in `/home/me/code` (because `code` was what you had searched for). This feature is still in development, and feedback is welcome.
+You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`. If you do that, Zsh-z will not jump to a common prefix, even if one exists. Instead, it chooses the highest-ranking match -- but it drops any subdirectories that do not include the search term. So if you type `z bat` and `/home/me/code/bat` is the best match, that is exactly where you will end up. If, however, you had typed `z code` and the best match was also `/home/me/code/bat`, you would have ended up in `/home/me/code` (because `code` was what you had searched for). This feature is still in development, and feedback is welcome.
 
 ## Improvements and Fixes
 
 * `z -x` works, with the help of `chpwd_functions`.
-* ZSH-z works on Solaris.
-* ZSH-z uses the "new" `zshcompsys` completion system instead of the old `compctl` one.
+* Zsh-z works on Solaris.
+* Zsh-z uses the "new" `zshcompsys` completion system instead of the old `compctl` one.
 * There is no error message when the database file has not yet been created.
 * There is support for special characters (e.g., `[`) in directory names.
 * If `z -l` only returns one match, a common root is not printed.
@@ -294,15 +296,15 @@ You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`.
 
 ## Migrating from Other Tools
 
-ZSH-z's database format is identical to that of `rupa/z`. You may switch freely between the two tools (I still use `rupa/z` for `bash`). `fasd` also uses that database format, but it stores it by default in `~/.fasd`, so you will have to `cp ~/.fasd ~/.z` if you want to use your old directory history.
+Zsh-z's database format is identical to that of `rupa/z`. You may switch freely between the two tools (I still use `rupa/z` for `bash`). `fasd` also uses that database format, but it stores it by default in `~/.fasd`, so you will have to `cp ~/.fasd ~/.z` if you want to use your old directory history.
 
-If you are coming to ZSH-z (or even to the original `rupa/z`, for that matter) from `autojump`, try using my [`jumpstart-z`](https://github.com/agkozak/jumpstart-z/blob/master/jumpstart-z) tool to convert your old database to the ZSH-z format, or simply run
+If you are coming to Zsh-z (or even to the original `rupa/z`, for that matter) from `autojump`, try using my [`jumpstart-z`](https://github.com/agkozak/jumpstart-z/blob/master/jumpstart-z) tool to convert your old database to the Zsh-z format, or simply run
 
     awk -F "\t" '{printf("%s|%0.f|%s\n", $2, $1, '"$(date +%s)"')}' < /path/to/autojump.txt > ~/.z
 
 ## `COMPLETE_ALIASES`
 
-`z`, or any alternative you set up using `$ZSH_CMD` or `$_Z_CMD`, is an alias. `setopt COMPLETE_ALIASES` divorces the tab completion for aliases from the underlying commands they invoke, so if you enable `COMPLETE_ALIASES`, tab completion for ZSH-z will be broken. You can get it working again, however, by adding under
+`z`, or any alternative you set up using `$ZSH_CMD` or `$_Z_CMD`, is an alias. `setopt COMPLETE_ALIASES` divorces the tab completion for aliases from the underlying commands they invoke, so if you enable `COMPLETE_ALIASES`, tab completion for Zsh-z will be broken. You can get it working again, however, by adding under
 
     setopt COMPLETE_ALIASES
 
@@ -310,7 +312,7 @@ the line
 
     compdef _zshz ${ZSHZ_CMD:-${_Z_CMD:-z}}
 
-That will re-bind `z` or the command of your choice to the underlying ZSH-z function.
+That will re-bind `z` or the command of your choice to the underlying Zsh-z function.
 
 ## Known Bugs
 It is possible to run a completion on a string with spaces in it, e.g., `z us bi<TAB>` might take you to `/usr/local/bin`. This works, but as things stand, after the completion the command line reads

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ to install `zsh-z`.
 - `-r`    Match by rank (i.e. how much time you spend in directories)
 - `-t`    Time -- match by how recently you have been to directories
 - `-x`    Remove the current directory from the database
+- `-xR`   Remove the current directory and its subdirectories from the database
 
 # Settings
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Then run
 
 and restart your shell.
 
-### For Zinit (formerly `zplugin`) users
+### For [Zinit](https://github.com/zdharma-continuum/zinit) users
 
 Add the line
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Add a backslash to the end of the last line add `'zsh-z'` to the list, e.g.,
 
 Then relaunch `zsh`.
 
+### For [zcomet](https://github.com/agkozak/zcomet) users
+        
+Simply add
+
+    zcomet load agkozak/zsh-z
+
+to your `.zshrc` (below where you source `zcomet.zsh` and above where you load `compinit`).
+
 ### For [zgen](https://github.com/tarjoilija/zgen) users
 
 Add the line

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![ZSH-z demo](img/demo.gif)
 
-ZSH-z is a command line tool that allows you to jump quickly to directories that you have visited frequently in the past, or recently -- but most often a combination of the two (a concept known as ["frecency"](https://en.wikipedia.org/wiki/Frecency)). It works by keeping track of when you go to directories and how much time you spend in them. It is then in the position to guess where you want to go when you type a partial string, e.g. `z src` might take you to `~/src/zsh`. `z zsh` might also get you there, and `z c/z` might prove to be even more specific -- it all depends on your habits and how much time you have been using ZSH-z to build up a database. After using ZSH-z for a little while, you will get to where you want to be by typing considerably less than you would need if you were using `cd`.
+ZSH-z is a command line tool that allows you to jump quickly to directories that you have visited frequently in the past, or recently -- but most often a combination of the two (a concept known as ["frecency"](https://en.wikipedia.org/wiki/Frecency)). It works by keeping track of when you go to directories and how much time you spend in them. It is then in the position to guess where you want to go when you type a partial string, e.g., `z src` might take you to `~/src/zsh`. `z zsh` might also get you there, and `z c/z` might prove to be even more specific -- it all depends on your habits and how much time you have been using ZSH-z to build up a database. After using ZSH-z for a little while, you will get to where you want to be by typing considerably less than you would need if you were using `cd`.
 
 ZSH-z is a native ZSH port of [rupa/z](https://github.com/rupa/z), a tool written for `bash` and ZSH that uses embedded `awk` scripts to do the heavy lifting. It was quite possibly my most used command line tool for a couple of years. I decided to translate it, `awk` parts and all, into pure ZSH script, to see if by eliminating calls to external tools (`awk`, `sort`, `date`, `sed`, `mv`, `rm`, and `chown`) and reducing forking through subshells I could make it faster. The performance increase is impressive, particularly on systems where forking is slow, such as Cygwin, MSYS2, and WSL. I have found that, in those environments, switching directories using ZSH-z can be over 100% faster than it is using `rupa/z`.
 
@@ -33,32 +33,36 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- July 10, 2021
+    + Setting `ZSHZ_TRAILING_SLASH=1` makes it so that a search pattern ending in `/` can match the end of a path; e.g. `z foo/` can match `/path/to/foo`.
+- June 25, 2021
+    + Setting `ZSHZ_TILDE=1` displays the `HOME` directory as `~`.
 - May 7, 2021
-  + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when you change directories.
-  + Better escaping of path names to deal paths containing the characters ``\`()[]``.
+    + Setting `ZSHZ_ECHO=1` will cause ZSH-z to display the new path when you change directories.
+    + Better escaping of path names to deal paths containing the characters ``\`()[]``.
 - February 15, 2021
-  + Ranks are displayed the way `rupa/z` now displays them, i.e. as large integers. This should help ZSH-z to integrate with other tools.
+    + Ranks are displayed the way `rupa/z` now displays them, i.e. as large integers. This should help ZSH-z to integrate with other tools.
 - January 31, 2021
-  + ZSH-z is now efficient enough that, on MSYS2 and Cygwin, it is faster to run it in the foreground than it is to fork a subshell for it.
-  + `_zshz_precmd` simply returns if `PWD` is `HOME` or in `ZSH_EXCLUDE_DIRS`, rather than waiting for `zshz` to do that.
+    + ZSH-z is now efficient enough that, on MSYS2 and Cygwin, it is faster to run it in the foreground than it is to fork a subshell for it.
+    + `_zshz_precmd` simply returns if `PWD` is `HOME` or in `ZSH_EXCLUDE_DIRS`, rather than waiting for `zshz` to do that.
 - January 17, 2021
-  + Made sure that the `PUSHD_IGNORE_DUPS` option is respected.
+    + Made sure that the `PUSHD_IGNORE_DUPS` option is respected.
 - January 14, 2021
-  + The `z -h` help text now breaks at spaces.
-  + `z -l` was not working for ZSH version < 5.
+    + The `z -h` help text now breaks at spaces.
+    + `z -l` was not working for ZSH version < 5.
 - January 11, 2021
-  + Major refactoring of the code.
-  + `z -lr` and `z -lt` work as expected.
-  + `EXTENDED_GLOB` has been disabled within the plugin to accomodate old-fashioned Windows directories with names such as `Progra~1`.
-  + Removed `zshelldoc` documentation.
+    + Major refactoring of the code.
+    + `z -lr` and `z -lt` work as expected.
+    + `EXTENDED_GLOB` has been disabled within the plugin to accomodate old-fashioned Windows directories with names such as `Progra~1`.
+    + Removed `zshelldoc` documentation.
 - January 6, 2021
-  + I have corrected the frecency routine so that it matches `rupa/z`'s math, but for the present, ZSH-z will continue to display ranks as 1/10000th of what they are in `rupa/z` -- [they had to multiply theirs by 10000](https://github.com/rupa/z/commit/f1f113d9bae9effaef6b1e15853b5eeb445e0712) to work around `bash`'s inadequacies at dealing with decimal fractions.
+    + I have corrected the frecency routine so that it matches `rupa/z`'s math, but for the present, ZSH-z will continue to display ranks as 1/10000th of what they are in `rupa/z` -- [they had to multiply theirs by 10000](https://github.com/rupa/z/commit/f1f113d9bae9effaef6b1e15853b5eeb445e0712) to work around `bash`'s inadequacies at dealing with decimal fractions.
 - January 5, 2021
-  + If you try `z foo`, and `foo` is not in the database but `${PWD}/foo` is a valid directory, ZSH-z will `cd` to it.
+    + If you try `z foo`, and `foo` is not in the database but `${PWD}/foo` is a valid directory, ZSH-z will `cd` to it.
 - December 22, 2020
-  + `ZSHZ_CASE`: when set to `ignore`, pattern matching is case-insensitive; when set to `smart`, patterns are matched case-insensitively when they are all lowercase and case-sensitively when they have uppercase characters in them (a behavior very much like Vim's `smartcase` setting).
-  + `ZSHZ_KEEP_DIRS` is an array of directory names that should not be removed from the database, even if they are not currently available (useful when a drive is not always mounted).
-  + Symlinked datafiles were having their symlinks overwritten; this bug has been fixed.
+    + `ZSHZ_CASE`: when set to `ignore`, pattern matching is case-insensitive; when set to `smart`, patterns are matched case-insensitively when they are all lowercase and case-sensitively when they have uppercase characters in them (a behavior very much like Vim's `smartcase` setting).
+    + `ZSHZ_KEEP_DIRS` is an array of directory names that should not be removed from the database, even if they are not currently available (useful when a drive is not always mounted).
+    + Symlinked datafiles were having their symlinks overwritten; this bug has been fixed.
 
 </details>
 
@@ -96,7 +100,7 @@ Execute the following command:
 
     git clone https://github.com/agkozak/zsh-z $ZSH_CUSTOM/plugins/zsh-z
 
-and add `zsh-z` to the line of your `.zshrc` that specifies `plugins=()`, e.g. `plugins=( git zsh-z )`.
+and add `zsh-z` to the line of your `.zshrc` that specifies `plugins=()`, e.g., `plugins=( git zsh-z )`.
 
 ### For [prezto](https://github.com/sorin-ionescu/prezto) users
 
@@ -121,7 +125,7 @@ is uncommented. Then find the section that specifies which modules are to be loa
         'completion' \
         'prompt'
 
-Add a backslash to the end of the last line add `'zsh-z'` to the list, e.g.
+Add a backslash to the end of the last line add `'zsh-z'` to the list, e.g.,
 
     zstyle ':prezto:load' pmodule \
         'environment' \
@@ -217,6 +221,8 @@ ZSH-z has environment variables (they all begin with `ZSHZ_`) that change its be
 * `ZSHZ_NO_RESOLVE_SYMLINKS` prevents symlink resolution (default: `0`)
 * `ZSHZ_OWNER` allows usage when in `sudo -s` mode (default: empty)
 * `ZSHZ_TILDE` displays the name of the `HOME` directory as a `~` (default: `0`)
+* `ZSHZ_TRAILING_SLASH` makes it so that a search pattern ending in `/` can match the final element in a path; e.g., `z foo/` can match `/path/to/foo` (default: `0`)
+* `ZSHZ_UNCOMMON` changes the logic used to calculate the directory jumped to; [see below](#zshz_uncommon`) (default: `0`)
 
 ## Case sensitivity
 
@@ -255,7 +261,7 @@ You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`.
 * ZSH-z works on Solaris.
 * ZSH-z uses the "new" `zshcompsys` completion system instead of the old `compctl` one.
 * There is no error message when the database file has not yet been created.
-* There is support for special characters (e.g. `[`) in directory names.
+* There is support for special characters (e.g., `[`) in directory names.
 * If `z -l` only returns one match, a common root is not printed.
 * Exit status codes increasingly make sense.
 * Completions work with options `-c`, `-r`, and `-t`.
@@ -280,7 +286,7 @@ the line
 That will re-bind `z` or the command of your choice to the underlying ZSH-z function.
 
 ## Known Bugs
-It is possible to run a completion on a string with spaces in it, e.g. `z us bi<TAB>` might take you to `/usr/local/bin`. This works, but as things stand, after the completion the command line reads
+It is possible to run a completion on a string with spaces in it, e.g., `z us bi<TAB>` might take you to `/usr/local/bin`. This works, but as things stand, after the completion the command line reads
 
     z us /usr/local/bin.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
-- Unreleased
+- November 11, 2021
     + A bug was fixed which was preventing ranks from being incremented.
     + `--add` has been made to work with relative paths and has been documented for the user.
 - October 14, 2021

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- August 13, 2021
+    + Fixed the explanation string printed during completion so that it may be formatted with `zstyle`.
 - July 29, 2021
     + Temporarily disabling use of `print -v`, which seems to be mangling CJK multibyte strings.
 - July 27, 2021

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 - [Settings](#settings)
 - [Case Sensitivity](#case-sensitivity)
 - [`ZSHZ_UNCOMMON`](#zshz_uncommon)
-- [Improvements and Fixes](#improvements-and-fixes)
+- [Making `--add` work for you](#making-add-work-for-you)
+- [Other Improvements and Fixes](#other-improvements-and-fixes)
 - [Migrating from Other Tools](#migrating-from-other-tools)
 - [`COMPLETE_ALIASES`](#complete_aliases)
 - [Known Bugs](#known-bugs)
@@ -287,7 +288,20 @@ then there is no common prefix. In this case, `z code` will simply send you to t
 
 You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`. If you do that, Zsh-z will not jump to a common prefix, even if one exists. Instead, it chooses the highest-ranking match -- but it drops any subdirectories that do not include the search term. So if you type `z bat` and `/home/me/code/bat` is the best match, that is exactly where you will end up. If, however, you had typed `z code` and the best match was also `/home/me/code/bat`, you would have ended up in `/home/me/code` (because `code` was what you had searched for). This feature is still in development, and feedback is welcome.
 
-## Improvements and Fixes
+## Making `--add` Work for You
+
+Zsh-z internally uses the `--add` option to add paths to its database. @zachriggle pointed out to me that users might want to use `--add` themselves, so I have altered it a little to make it more user-friendly.
+
+A good example might involve a directory tree that has Git repositories within it. The working directories could be added to the Zsh-z database as a batch with
+
+    for i in $(find $PWD -maxdepth 3 -name .git -type d); do
+      z --add ${i:h}
+    done
+
+(As a Zsh user, I tend to use `**` instead of `find`, but it is good to see how deep your directory trees go before doing that.)
+
+
+## Other Improvements and Fixes
 
 * `z -x` works, with the help of `chpwd_functions`.
 * Zsh-z works on Solaris.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- Unreleased
+    + `z -xR` will now remove a directory *and its subdirectories* from the database.
+    + `z -x` and `z -xr` can now take an argument; without one, `PWD` is assumed.
 - August 27, 2021
     + Using `print -v ... -f` instead of `print -v` to work around longstanding bug in ZSH involving `print -v` and multibyte strings.
 - August 13, 2021
@@ -215,8 +218,8 @@ to install `zsh-z`.
 - `-l`    List all matches without going to them
 - `-r`    Match by rank (i.e. how much time you spend in directories)
 - `-t`    Time -- match by how recently you have been to directories
-- `-x`    Remove the current directory from the database
-- `-xR`   Remove the current directory and its subdirectories from the database
+- `-x`    Remove a directory (by default, the current directory) from the database
+- `-xR`   Remove a directory (by default, the current directory) and its subdirectories from the database
 
 # Settings
 
@@ -277,6 +280,7 @@ You may enable an alternate, experimental behavior by setting `ZSHZ_UNCOMMON=1`.
 * Exit status codes increasingly make sense.
 * Completions work with options `-c`, `-r`, and `-t`.
 * If `~/foo` and `~/foob` are matches, `~/foo` is *not* the common root. Only a common parent directory can be a common root.
+* `z -x` and the new, recursive `z -xR` can take an argument so that you can remove directories other than `PWD` from the database.
 
 ## Migrating from Other Tools
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- September 7, 2021
+    + Fixed the unload function so that it removes the `$ZSHZ_CMD` alias (default: `z`).
 - August 27, 2021
     + Using `print -v ... -f` instead of `print -v` to work around longstanding bug in ZSH involving `print -v` and multibyte strings.
 - August 13, 2021

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ZSH-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
-- Unreleased
+- September 23, 2021
     + `z -xR` will now remove a directory *and its subdirectories* from the database.
     + `z -x` and `z -xR` can now take an argument; without one, `PWD` is assumed.
 - September 7, 2021

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
-- Unreleased
+- September 25, 2021
     + Orthographical change: "Zsh," not "ZSH."
 - September 23, 2021
     + `z -xR` will now remove a directory *and its subdirectories* from the database.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- December 19, 2021
+    + ZSH-z will now display tildes for `HOME` during completion when `ZSHZ_TILDE=1` has been set.
 - November 11, 2021
     + A bug was fixed which was preventing ranks from being incremented.
     + `--add` has been made to work with relative paths and has been documented for the user.

--- a/_zshz
+++ b/_zshz
@@ -60,7 +60,7 @@ completions=$(zshz --complete ${(@)words:1})
 _description -V completions expl 'directories'
 
 if [[ $ZSHZ_COMPLETION == 'legacy' ]]; then
-  compadd "${expl[@]}" -U -- "${(f)completions}"
+  compadd "${expl[@]}" -U -- "${(f)completions[@]}"
 else
   compadd "${expl[@]}" -U -V zsh-z -- "${(f)completions[@]}"
 fi

--- a/_zshz
+++ b/_zshz
@@ -1,6 +1,6 @@
 #compdef zshz ${ZSHZ_CMD:-${_Z_CMD:-z}}
 #
-# ZSH-z - jump around with ZSH - A native ZSH version of z without awk, sort,
+# Zsh-z - jump around with Zsh - A native Zsh version of z without awk, sort,
 # date, or sed
 #
 # https://github.com/agkozak/zsh-z
@@ -31,7 +31,7 @@
 # shellcheck shell=ksh
 
 ############################################################
-# ZSH-z COMPLETIONS
+# Zsh-z COMPLETIONS
 ############################################################
 emulate -L zsh
 (( ZSHZ_DEBUG )) &&

--- a/_zshz
+++ b/_zshz
@@ -57,7 +57,7 @@ local completions expl
 completions=$(zshz --complete ${(@)words:1})
 [[ -z $completions ]] && return 1
 
-_description completions expl 'directories'
+_description -V completions expl 'directories'
 
 if [[ $ZSHZ_COMPLETION == 'legacy' ]]; then
   compadd "${expl[@]}" -U -- "${(f)completions}"

--- a/_zshz
+++ b/_zshz
@@ -52,17 +52,27 @@ emulate -L zsh
 #
 # Address.
 
-local completions expl
+local completions expl completion
+local -a completion_list
 
 completions=$(zshz --complete ${(@)words:1})
 [[ -z $completions ]] && return 1
 
-_description -V completions expl 'directories'
+for completion in ${(f)completions[@]}; do
+  if (( ZSHZ_TILDE )) && [[ $completion == ${HOME}* ]]; then
+    completion="~${(q)${completion#${HOME}}}"
+  else
+    completion="${(q)completion}"
+  fi
+  completion_list+=( $completion )
+done
+
+_description -V completion_list expl 'directories'
 
 if [[ $ZSHZ_COMPLETION == 'legacy' ]]; then
-  compadd "${expl[@]}" -U -- "${(f)completions[@]}"
+  compadd "${expl[@]}" -QU -- "${completion_list[@]}"
 else
-  compadd "${expl[@]}" -U -V zsh-z -- "${(f)completions[@]}"
+  compadd "${expl[@]}" -QU -V zsh-z -- "${completion_list[@]}"
 fi
 
 compstate[insert]=menu

--- a/_zshz
+++ b/_zshz
@@ -35,7 +35,7 @@
 ############################################################
 emulate -L zsh
 (( ZSHZ_DEBUG )) &&
-  setopt LOCAL_OPTIONS WARN_CREATE_GLOBAL WARN_NESTED_VAR 2> /dev/null
+  setopt LOCAL_OPTIONS WARN_CREATE_GLOBAL NO_WARN_NESTED_VAR 2> /dev/null
 
 # TODO: This routine currently reproduces z's feature of allowing spaces to be
 # used as wildcards in completions, so that
@@ -52,15 +52,17 @@ emulate -L zsh
 #
 # Address.
 
-local completions
+local completions expl
 
 completions=$(zshz --complete ${(@)words:1})
 [[ -z $completions ]] && return 1
 
+_description completions expl 'directories'
+
 if [[ $ZSHZ_COMPLETION == 'legacy' ]]; then
-  compadd -x 'Completing directory' -U "${(f)completions}"
+  compadd "${expl[@]}" -U -- "${(f)completions}"
 else
-  compadd -x 'Completing directory' -U -V zsh-z "${(f)completions}"
+  compadd "${expl[@]}" -U -V zsh-z -- "${(f)completions[@]}"
 fi
 
 compstate[insert]=menu

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -476,7 +476,8 @@ zshz() {
           fi
         done
         if [[ -n $common ]]; then
-          (( $#output > 1 )) && printf "%-10s%s\n" 'common:' $common
+          (( ZSHZ_TILDE )) && common=${common/#${HOME}/\~}
+          (( $#output > 1 )) && printf "%-10s %s\n" 'common:' $common
         fi
         # -lt
         if (( $+opts[-t] )); then

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -1,5 +1,5 @@
 ################################################################################
-# ZSH-z - jump around with ZSH - A native ZSH version of z without awk, sort,
+# Zsh-z - jump around with Zsh - A native Zsh version of z without awk, sort,
 # date, or sed
 #
 # https://github.com/agkozak/zsh-z
@@ -27,7 +27,7 @@
 # z (https://github.com/rupa/z) is copyright (c) 2009 rupa deadwyler and
 # licensed under the WTFPL license, Version 2.
 #
-# ZSH-z maintains a jump-list of the directories you actually use.
+# Zsh-z maintains a jump-list of the directories you actually use.
 #
 # INSTALL:
 #   * put something like this in your .zshrc:
@@ -63,7 +63,7 @@
 #   ZSHZ_MAX_SCORE -> maximum combined score the database entries can have
 #     before beginning to age (default: 9000)
 #   ZSHZ_NO_RESOLVE_SYMLINKS -> '1' prevents symlink resolution
-#   ZSHZ_OWNER -> your username (if you want use ZSH-z while using sudo -s)
+#   ZSHZ_OWNER -> your username (if you want use Zsh-z while using sudo -s)
 #   ZSHZ_UNCOMMON -> if 1, do not jump to "common directories," but rather drop
 #     subdirectories based on what the search string was (default: 0)
 ################################################################################
@@ -71,7 +71,7 @@
 autoload -U is-at-least
 
 if ! is-at-least 4.3.11; then
-  print "ZSH-z requires ZSH v4.3.11 or higher." >&2 && exit
+  print "Zsh-z requires Zsh v4.3.11 or higher." >&2 && exit
 fi
 
 ############################################################
@@ -123,7 +123,7 @@ zsystem supports flock &> /dev/null && ZSHZ[USE_FLOCK]=1
 is-at-least 5.3.0 && ZSHZ[PRINTV]=1
 
 ############################################################
-# The ZSH-z Command
+# The Zsh-z Command
 #
 # Globals:
 #   ZSHZ
@@ -154,7 +154,7 @@ zshz() {
 
   # If the datafile is a directory, print a warning and exit
   if [[ -d $datafile ]]; then
-    print "ERROR: ZSH-z's datafile (${datafile}) is a directory." >&2
+    print "ERROR: Zsh-z's datafile (${datafile}) is a directory." >&2
     exit
   fi
 
@@ -235,7 +235,7 @@ zshz() {
         local -a lines_to_keep
         if (( ${+opts[-R]} )); then
           # Prompt user before deleting entire database
-          if [[ $xdir == '/' ]] && ! read -q "?Delete entire ZSH-z database? "; then
+          if [[ $xdir == '/' ]] && ! read -q "?Delete entire Zsh-z database? "; then
             print && return 1
           fi
           # All of the lines that don't match the directory to be deleted
@@ -405,8 +405,8 @@ zshz() {
   #   foo=$( bar )
   #
   # requires forking a subshell; on Cygwin/MSYS2/WSL1 that can
-  # be surprisingly slow. ZSH-z avoids doing that by printing
-  # values to the variable REPLY. Since ZSH v5.3.0 that has
+  # be surprisingly slow. Zsh-z avoids doing that by printing
+  # values to the variable REPLY. Since Zsh v5.3.0 that has
   # been possible with `print -v'; for earlier versions of the
   # shell, the values are placed on the editing buffer stack
   # and then `read' into REPLY.
@@ -625,7 +625,7 @@ zshz() {
       # If it's 'smart', be case-insensitive unless the string to be matched
       # includes capital letters.
       #
-      # Otherwise, the default behavior of ZSH-z is to match case-sensitively if
+      # Otherwise, the default behavior of Zsh-z is to match case-sensitively if
       # possible, then to fall back on a case-insensitive match if possible.
       if [[ $ZSHZ_CASE == 'smart' && ${1:l} == $1 &&
             ${path_field_normalized:l} == ${~q:l} ]]; then
@@ -859,7 +859,7 @@ _zshz_precmd() {
 # chpwd
 #
 # When the $PWD is removed from the datafile with `z -x',
-# ZSH-z refrains from adding it again until the user has
+# Zsh-z refrains from adding it again until the user has
 # left the directory.
 #
 # Globals:

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -571,11 +571,11 @@ zshz() {
       # Otherwise, the default behavior of ZSH-z is to match case-sensitively if
       # possible, then to fall back on a case-insensitive match if possible.
       if [[ $ZSHZ_CASE == 'smart' && ${1:l} == $1 &&
-            ${path_field:l} == ${~q:l} ]]; then
+            "${path_field:l}/" == ${~q:l} ]]; then
         imatches[$path_field]=$rank
-      elif [[ $ZSHZ_CASE != 'ignore' && $path_field == ${~q} ]]; then
+      elif [[ $ZSHZ_CASE != 'ignore' && "${path_field}/" == ${~q} ]]; then
         matches[$path_field]=$rank
-      elif [[ $ZSHZ_CASE != 'smart' && ${path_field:l} == ${~q:l} ]]; then
+      elif [[ $ZSHZ_CASE != 'smart' && "${path_field:l}/" == ${~q:l} ]]; then
         imatches[$path_field]=$rank
       fi
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -108,6 +108,10 @@ With no ARGUMENT, list the directory history in ascending rank.
 # Global associative array for internal use
 typeset -gA ZSHZ
 
+# Make sure ZSHZ_EXCLUDE_DIRS has been declared so that other scripts can
+# simply append to it
+(( ${+ZSHZ_EXCLUDE_DIRS} )) || typeset -ga ZSHZ_EXCLUDE_DIRS
+
 # Determine if zsystem flock is available
 zsystem supports flock &> /dev/null && ZSHZ[USE_FLOCK]=1
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -938,6 +938,7 @@ zsh-z_plugin_unload() {
 
   fpath=( "${(@)fpath:#${0:A:h}}" )
 
+  # TODO: The following does not work.
   (( $+aliases[$ZSHZ_CMD:-${_Z_CMD:-z}] )) && unalias ${ZSHZ_CMD:-${_Z_CMD:-z}}
 
   unfunction $0

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -869,7 +869,7 @@ _zshz_chpwd() {
   ZSHZ[DIRECTORY_REMOVED]=0
 }
 
-autoload -U add-zsh-hook
+autoload -Uz add-zsh-hook
 
 add-zsh-hook precmd _zshz_precmd
 add-zsh-hook chpwd _zshz_chpwd

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -393,7 +393,9 @@ zshz() {
   #   Options and parameters for `print'
   ############################################################
   _zshz_printv() {
-    # Attempt at fixing CJK character problem
+    # TODO: `print -v' seems to be mangling CJK multibyte strings. I shall
+    # continue to research this matter; in the meantime, `print -z'/`read -rz'
+    # works perfectly.
 
     # if (( ZSHZ[PRINTV] )); then
     #   builtin print -v REPLY $@

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -575,14 +575,18 @@ zshz() {
         imatches[$path_field]=$rank
       fi
 
-      if (( matches[$path_field] )) &&
-         (( matches[$path_field] > hi_rank )); then
+      # Escape characters that would cause "invalid subscript" errors
+      # when accessing the associative array.
+      escaped_path_field=${(b)path_field}
+
+      if (( matches[$escaped_path_field] )) &&
+         (( matches[$escaped_path_field] > hi_rank )); then
         best_match=$path_field
-        hi_rank=${matches[$path_field]}
-      elif (( imatches[$path_field] )) &&
-           (( imatches[$path_field] > ihi_rank )); then
+        hi_rank=${matches[$escaped_path_field]}
+      elif (( imatches[$escaped_path_field] )) &&
+           (( imatches[$escaped_path_field] > ihi_rank )); then
         ibest_match=$path_field
-        ihi_rank=${imatches[$path_field]}
+        ihi_rank=${imatches[$escaped_path_field]}
         ZSHZ[CASE_INSENSITIVE]=1
       fi
     done

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -599,7 +599,12 @@ zshz() {
 
       # Escape characters that would cause "invalid subscript" errors
       # when accessing the associative array.
-      escaped_path_field=${(b)path_field}
+      escaped_path_field=${path_field//'\'/'\\'}
+      escaped_path_field=${escaped_path_field//'`'//'\`'}
+      escaped_path_field=${escaped_path_field//'('/'\('}
+      escaped_path_field=${escaped_path_field//')'/'\)'}
+      escaped_path_field=${escaped_path_field//'['/'\['}
+      escaped_path_field=${escaped_path_field//']'/'\]'}
 
       if (( matches[$escaped_path_field] )) &&
          (( matches[$escaped_path_field] > hi_rank )); then

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -110,7 +110,7 @@ typeset -gA ZSHZ
 
 # Make sure ZSHZ_EXCLUDE_DIRS has been declared so that other scripts can
 # simply append to it
-(( ${+ZSHZ_EXCLUDE_DIRS} )) || typeset -ga ZSHZ_EXCLUDE_DIRS
+(( ${+ZSHZ_EXCLUDE_DIRS} )) || typeset -gUa ZSHZ_EXCLUDE_DIRS
 
 # Determine if zsystem flock is available
 zsystem supports flock &> /dev/null && ZSHZ[USE_FLOCK]=1

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -393,12 +393,14 @@ zshz() {
   #   Options and parameters for `print'
   ############################################################
   _zshz_printv() {
-    if (( ZSHZ[PRINTV] )); then
-      builtin print -v REPLY $@
-    else
+    # Attempt at fixing CJK character problem
+
+    # if (( ZSHZ[PRINTV] )); then
+    #   builtin print -v REPLY $@
+    # else
       builtin print -z $@
       builtin read -rz REPLY
-    fi
+    # fi
   }
 
   ############################################################

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -521,7 +521,7 @@ zshz() {
     local fnd=$1 method=$2 format=$3
 
     local -a existing_paths
-    local line dir path_field rank_field time_field rank dx
+    local line dir path_field rank_field time_field rank dx escaped_path_field
     local -A matches imatches
     local best_match ibest_match hi_rank=-9999999999 ihi_rank=-9999999999
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -393,16 +393,26 @@ zshz() {
   #   Options and parameters for `print'
   ############################################################
   _zshz_printv() {
-    # TODO: `print -v' seems to be mangling CJK multibyte strings. I shall
-    # continue to research this matter; in the meantime, `print -z'/`read -rz'
-    # works perfectly.
+    # NOTE: For a long time, ZSH's `print -v' had a tendency
+    # to mangle multibyte strings:
+    #
+    #   https://www.zsh.org/mla/workers/2020/msg00307.html
+    #
+    # The bug was fixed in late 2020:
+    #
+    #   https://github.com/zsh-users/zsh/commit/b6ba74cd4eaec2b6cb515748cf1b74a19133d4a4#diff-32bbef18e126b837c87b06f11bfc61fafdaa0ed99fcb009ec53f4767e246b129
+    #
+    # In order to support shells with the bug, we must use a form of `printf`,
+    # which does not exhibit the undesired behavior. See
+    #
+    #   https://www.zsh.org/mla/workers/2020/msg00308.html
 
-    # if (( ZSHZ[PRINTV] )); then
-    #   builtin print -v REPLY $@
-    # else
+    if (( ZSHZ[PRINTV] )); then
+      builtin print -v REPLY -f %s $@
+    else
       builtin print -z $@
       builtin read -rz REPLY
-    # fi
+    fi
   }
 
   ############################################################

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -658,7 +658,8 @@ zshz() {
   }
 
   if [[ ${@: -1} == /* ]] && (( ! $+opts[-e] && ! $+opts[-l] )); then
-    [[ -d ${@: -1} ]] && builtin cd ${@: -1} && return
+    [[ -d ${@: -1} ]] && builtin cd ${@: -1} &&
+      (( $+ZSHZ_ECHO )) && print $PWD && return
   fi
 
   # With option -c, make sure query string matches beginning of matches;
@@ -712,12 +713,12 @@ zshz() {
     if (( $+opts[-e] )); then               # echo
       print -- "$cd"
     else
-      [[ -d $cd ]] && builtin cd "$cd"
+      [[ -d $cd ]] && builtin cd "$cd" && (( $+ZSHZ_ECHO )) && print $PWD
     fi
   else
     # if $req is a valid path, cd to it
     if ! (( $+opts[-e] || $+opts[-l] )) && [[ -d $req ]]; then
-      builtin cd "$req"
+      builtin cd "$req" && (( $+ZSHZ_ECHO )) && print $PWD
     else
       return $ret2
     fi

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -35,16 +35,17 @@
 #   * cd around for a while to build up the database
 #
 # USAGE:
-#   * z foo     # cd to the most frecent directory matching foo
-#   * z foo bar # cd to the most frecent directory matching both foo and bar
+#   * z foo       cd to the most frecent directory matching foo
+#   * z foo bar   cd to the most frecent directory matching both foo and bar
 #                   (e.g. /foo/bat/bar/quux)
-#   * z -r foo  # cd to the highest ranked directory matching foo
-#   * z -t foo  # cd to most recently accessed directory matching foo
-#   * z -l foo  # List matches instead of changing directories
-#   * z -e foo  # Echo the best match without changing directories
-#   * z -c foo  # Restrict matches to subdirectories of PWD
-#   * z -x      # Remove PWD from the database
-#   * z -xR     # Remove PWD and its subdirectories from the database
+#   * z -r foo    cd to the highest ranked directory matching foo
+#   * z -t foo    cd to most recently accessed directory matching foo
+#   * z -l foo    List matches instead of changing directories
+#   * z -e foo    Echo the best match without changing directories
+#   * z -c foo    Restrict matches to subdirectories of PWD
+#   * z -x        Remove a directory (default: PWD) from the database
+#   * z -xR       Remove a directory (default: PWD) and its subdirectories from
+#                   the database
 #
 # ENVIRONMENT VARIABLES:
 #
@@ -91,8 +92,9 @@ With no ARGUMENT, list the directory history in ascending rank.
   -l    List all matches without going to them
   -r    Match by rank
   -t    Match by recent access
-  -x    Remove the current directory from the database
-  -xR   Remove the current directory and its subdirectories from the database" | fold -s >&2
+  -x    Remove a directory from the database (by default, the current directory)
+  -xR   Remove a directory and its subdirectories from the datbase (by default, the current directory)" |
+    fold -s -w $COLUMNS >&2
 }
 
 # Load zsh/datetime module, if necessary
@@ -223,9 +225,11 @@ zshz() {
         local xdir  # Directory to be removed
 
         if (( ${ZSHZ_NO_RESOLVE_SYMLINKS:-${_Z_NO_RESOLVE_SYMLINKS}} )); then
-          xdir=${PWD:a}
+#          [[ -d ${*:a} ]] && xdir=${*:a} || xdir=${PWD:a}
+          [[ -d ${${*:-${PWD}}:a} ]] && xdir=${${*:-${PWD}}:a}
         else
-          xdir=${PWD:A}
+          [[ -d ${${*:-${PWD}}:A} ]] && xdir=${${*:-${PWD}}:a}
+#          [[ -d ${*:A} ]] && xdir=${*:a} || xdir=${PWD:A}
         fi
 
         local -a lines_to_keep
@@ -708,7 +712,7 @@ zshz() {
       -r) method='rank' ;;
       -t) method='time' ;;
       -x)
-        _zshz_add_or_remove_path --remove
+        _zshz_add_or_remove_path --remove $*
         return
         ;;
     esac

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -229,7 +229,7 @@ zshz() {
     owner=${ZSHZ_OWNER:-${_Z_OWNER}}
 
     if (( ZSHZ[USE_FLOCK] )); then
-      zf_mv "$tempfile" "$datafile" || zf_rm -f "$tempfile"
+      zf_mv "$tempfile" "$datafile" 2> /dev/null || zf_rm -f "$tempfile"
 
       if [[ -n $owner ]]; then
         zf_chown ${owner}:"$(id -ng ${owner})" "$datafile"

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -237,7 +237,7 @@ zshz() {
           # All of the lines that don't match the directory to be deleted
           lines_to_keep=( ${lines:#${xdir}\|*} )
           # Or its subdirectories
-          lines_to_keep=( ${lines_to_keep:#${xdir}/**} )
+          lines_to_keep=( ${lines_to_keep:#${xdir%/}/**} )
         else
           # All of the lines that don't match the directory to be deleted
           lines_to_keep=( ${lines:#${xdir}\|*} )

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -671,7 +671,7 @@ zshz() {
   # the home directory as a tilde.
   #########################################################
   _zshz_echo() {
-    if (( $+ZSHZ_ECHO )); then
+    if (( $ZSHZ_ECHO )); then
       if (( $ZSHZ_TILDE )); then
         print ${PWD/#${HOME}/\~}
       else

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -715,6 +715,7 @@ zshz() {
 
       # In the search pattern, replace spaces with *
       local q=${fnd//[[:space:]]/\*}
+      q=${q%/} # Trailing slash has to be removed
 
       # As long as the best match is not case-insensitive
       if (( ! ZSHZ[CASE_INSENSITIVE] )); then

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -604,7 +604,7 @@ zshz() {
       # Escape characters that would cause "invalid subscript" errors
       # when accessing the associative array.
       escaped_path_field=${path_field//'\'/'\\'}
-      escaped_path_field=${escaped_path_field//'`'//'\`'}
+      escaped_path_field=${escaped_path_field//'`'/'\`'}
       escaped_path_field=${escaped_path_field//'('/'\('}
       escaped_path_field=${escaped_path_field//')'/'\)'}
       escaped_path_field=${escaped_path_field//'['/'\['}

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -563,6 +563,12 @@ zshz() {
       # Use spaces as wildcards
       local q=${fnd//[[:space:]]/\*}
 
+      # If $ZSHZ_TRAILING_SLASH is set, use path_field with a trailing slash for matching.
+      local path_field_normalized=$path_field
+      if (( ZSHZ_TRAILING_SLASH )); then
+        path_field_normalized=${path_field%/}/
+      fi
+
       # If $ZSHZ_CASE is 'ignore', be case-insensitive.
       #
       # If it's 'smart', be case-insensitive unless the string to be matched
@@ -571,11 +577,11 @@ zshz() {
       # Otherwise, the default behavior of ZSH-z is to match case-sensitively if
       # possible, then to fall back on a case-insensitive match if possible.
       if [[ $ZSHZ_CASE == 'smart' && ${1:l} == $1 &&
-            "${path_field:l}/" == ${~q:l} ]]; then
+            ${path_field_normalized:l} == ${~q:l} ]]; then
         imatches[$path_field]=$rank
-      elif [[ $ZSHZ_CASE != 'ignore' && "${path_field}/" == ${~q} ]]; then
+      elif [[ $ZSHZ_CASE != 'ignore' && $path_field_normalized == ${~q} ]]; then
         matches[$path_field]=$rank
-      elif [[ $ZSHZ_CASE != 'smart' && "${path_field:l}/" == ${~q:l} ]]; then
+      elif [[ $ZSHZ_CASE != 'smart' && ${path_field_normalized:l} == ${~q:l} ]]; then
         imatches[$path_field]=$rank
       fi
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -519,9 +519,9 @@ zshz() {
   }
 
   ############################################################
-  # Load the datafile, and match a pattern by rank, time, or a
-  # combination of the two, and output the results as
-  # completions, a list, or a best match.
+  # Match a pattern by rank, time, or a combination of the
+  # two, and output the results as completions, a list, or a
+  # best match.
   #
   # Globals:
   #   ZSHZ

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -338,8 +338,8 @@ zshz() {
         rank[$path_field]=$(( rank_field + 1 ))
         time[$path_field]=$now
       else
-        rank[$path_field]=$(( rank_field ))
-        time[$path_field]=$(( time_field ))
+        rank[$path_field]=$rank_field
+        time[$path_field]=$time_field
       fi
       (( count += rank_field ))
     done

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -938,8 +938,8 @@ zsh-z_plugin_unload() {
 
   fpath=( "${(@)fpath:#${0:A:h}}" )
 
-  # TODO: The following does not work.
-  (( $+aliases[$ZSHZ_CMD:-${_Z_CMD:-z}] )) && unalias ${ZSHZ_CMD:-${_Z_CMD:-z}}
+  (( ${+aliases[${ZSHZ_CMD:-${_Z_CMD:-z}}]} )) &&
+    unalias ${ZSHZ_CMD:-${_Z_CMD:-z}}
 
   unfunction $0
 }

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -219,8 +219,15 @@ zshz() {
         ;;
       --remove)
         local -a lines_to_keep
-        # All of the lines that don't match the directory to be deleted
-        lines_to_keep=( ${lines:#${PWD}\|*} )
+        if (( ${+opts[-R]} )); then
+          # All of the lines that don't match the directory to be deleted
+          lines_to_keep=( ${lines:#${PWD}\|*} )
+          # Or its subdirectories
+          lines_to_keep=( ${lines_to_keep:#${PWD}/**} )
+        else
+          # All of the lines that don't match the directory to be deleted
+          lines_to_keep=( ${lines:#${PWD}\|*} )
+        fi
         if [[ $lines != "$lines_to_keep" ]]; then
           lines=( $lines_to_keep )
         else
@@ -645,6 +652,7 @@ zshz() {
     -help \
     l \
     r \
+    R \
     t \
     x
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -912,7 +912,8 @@ zsh-z_plugin_unload() {
 
   fpath=( "${(@)fpath:#${0:A:h}}" )
 
-  (( $+aliases[$ZSHZ_CMD:-${_Z_CMD:-z}] )) && unalias ${ZSHZ_CMD:-${_Z_CMD:-z}}
+  (( ${+aliases[${ZSHZ_CMD:-${_Z_CMD:-z}}]} )) &&
+    unalias ${ZSHZ_CMD:-${_Z_CMD:-z}}
 
   unfunction $0
 }

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -218,15 +218,23 @@ zshz() {
         local ret=$?
         ;;
       --remove)
+        local xdir  # Directory to be removed
+
+        if (( ${ZSHZ_NO_RESOLVE_SYMLINKS:-${_Z_NO_RESOLVE_SYMLINKS}} )); then
+          xdir=${PWD:a}
+        else
+          xdir=${PWD:A}
+        fi
+
         local -a lines_to_keep
         if (( ${+opts[-R]} )); then
           # All of the lines that don't match the directory to be deleted
-          lines_to_keep=( ${lines:#${PWD}\|*} )
+          lines_to_keep=( ${lines:#${xdir}\|*} )
           # Or its subdirectories
-          lines_to_keep=( ${lines_to_keep:#${PWD}/**} )
+          lines_to_keep=( ${lines_to_keep:#${xdir}/**} )
         else
           # All of the lines that don't match the directory to be deleted
-          lines_to_keep=( ${lines:#${PWD}\|*} )
+          lines_to_keep=( ${lines:#${xdir}\|*} )
         fi
         if [[ $lines != "$lines_to_keep" ]]; then
           lines=( $lines_to_keep )

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -93,7 +93,7 @@ With no ARGUMENT, list the directory history in ascending rank.
   -r    Match by rank
   -t    Match by recent access
   -x    Remove a directory from the database (by default, the current directory)
-  -xR   Remove a directory and its subdirectories from the datbase (by default, the current directory)" |
+  -xR   Remove a directory and its subdirectories from the database (by default, the current directory)" |
     fold -s -w $COLUMNS >&2
 }
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -879,7 +879,7 @@ add-zsh-hook chpwd _zshz_chpwd
 ############################################################
 
 # Standarized $0 handling
-# (See https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc)
+# (See https://github.com/agkozak/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc)
 0=${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}
 0=${${(M)0:#/*}:-$PWD/$0}
 
@@ -917,7 +917,7 @@ ZSHZ[FUNCTIONS]='_zshz_usage
 ############################################################
 # Unload function
 #
-# See https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc#unload-fun
+# See https://github.com/agkozak/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc#unload-fun
 #
 # Globals:
 #   ZSHZ

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -92,7 +92,7 @@ With no ARGUMENT, list the directory history in ascending rank.
   -r    Match by rank
   -t    Match by recent access
   -x    Remove the current directory from the database
-  -xR   Remove the current directory from the database recursively" | fold -s >&2
+  -xR   Remove the current directory and its subdirectories from the database" | fold -s >&2
 }
 
 # Load zsh/datetime module, if necessary

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -278,7 +278,9 @@ zshz() {
     # In order to make z -x work, we have to disable zsh-z's adding
     # to the database until the user changes directory and the
     # chpwd_functions are run
-    [[ $action == '--remove' ]] && ZSHZ[DIRECTORY_REMOVED]=1
+    if [[ $action == '--remove' ]]; then
+      ZSHZ[DIRECTORY_REMOVED]=1
+    fi
   }
 
   ############################################################

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -464,7 +464,7 @@ zshz() {
         for x in ${(k)output_matches}; do
           if (( ${output_matches[$x]} )); then
             path_to_display=$x
-            (( $ZSHZ_TILDE )) &&
+            (( ZSHZ_TILDE )) &&
               path_to_display=${path_to_display/#${HOME}/\~}
             _zshz_printv -f "%-10d %s\n" ${output_matches[$x]} $path_to_display
             output+=( ${(f)REPLY} )
@@ -671,8 +671,8 @@ zshz() {
   # the home directory as a tilde.
   #########################################################
   _zshz_echo() {
-    if (( $ZSHZ_ECHO )); then
-      if (( $ZSHZ_TILDE )); then
+    if (( ZSHZ_ECHO )); then
+      if (( ZSHZ_TILDE )); then
         print ${PWD/#${HOME}/\~}
       else
         print $PWD
@@ -734,7 +734,7 @@ zshz() {
 
   if (( ret2 == 0 )) && [[ -n $cd ]]; then
     if (( $+opts[-e] )); then               # echo
-      (( $ZSHZ_TILDE )) && cd=${cd/#${HOME}/\~}
+      (( ZSHZ_TILDE )) && cd=${cd/#${HOME}/\~}
       print -- "$cd"
     else
       # cd if possible; echo the new path if $ZSHZ_ECHO == 1

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -662,6 +662,7 @@ zshz() {
   }
 
   if [[ ${@: -1} == /* ]] && (( ! $+opts[-e] && ! $+opts[-l] )); then
+    # cd if possible; echo the new path if $ZSHZ_ECHO == 1
     [[ -d ${@: -1} ]] && builtin cd ${@: -1} &&
       (( $+ZSHZ_ECHO )) && print $PWD && return
   fi
@@ -717,10 +718,11 @@ zshz() {
     if (( $+opts[-e] )); then               # echo
       print -- "$cd"
     else
+      # cd if possible; echo the new path if $ZSHZ_ECHO == 1
       [[ -d $cd ]] && builtin cd "$cd" && (( $+ZSHZ_ECHO )) && print $PWD
     fi
   else
-    # if $req is a valid path, cd to it
+    # if $req is a valid path, cd to it; echo the new path if $ZSHZ_ECHO == 1
     if ! (( $+opts[-e] || $+opts[-l] )) && [[ -d $req ]]; then
       builtin cd "$req" && (( $+ZSHZ_ECHO )) && print $PWD
     else

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -138,7 +138,7 @@ is-at-least 5.3.0 && ZSHZ[PRINTV]=1
 zshz() {
 
   # Don't use `emulate -L zsh' - it breaks PUSHD_IGNORE_DUPS
-  setopt LOCAL_OPTIONS NO_KSH_ARRAYS NO_SH_WORD_SPLIT
+  setopt LOCAL_OPTIONS NO_KSH_ARRAYS NO_SH_WORD_SPLIT EXTENDED_GLOB
   (( ZSHZ_DEBUG )) && setopt LOCAL_OPTIONS WARN_CREATE_GLOBAL
 
   local REPLY
@@ -164,6 +164,8 @@ zshz() {
 
   # Load the datafile into an array and parse it
   lines=( ${(f)"$(< $datafile)"} )
+  # Discard entries that are incomplete or incorrectly formatted
+  lines=( ${(M)lines:#/*\|[[:digit:]]##[.,]#[[:digit:]]#\|[[:digit:]]##} )
 
   ############################################################
   # Add a path to or remove one from the datafile

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -86,6 +86,7 @@ Jump to a directory that you have visited frequently or recently, or a bit of bo
 
 With no ARGUMENT, list the directory history in ascending rank.
 
+  --add Add a directory to the database
   -c    Only match subdirectories of the current directory
   -e    Echo the best match without going to it
   -h    Display this help and exit
@@ -697,7 +698,14 @@ zshz() {
   for opt in ${(k)opts}; do
     case $opt in
       --add)
-        _zshz_add_or_remove_path --add "$*"
+        [[ ! -d $* ]] && return 1
+        local dir
+        if (( ${ZSHZ_NO_RESOLVE_SYMLINKS:-${_Z_NO_RESOLVE_SYMLINKS}} )); then
+          dir=${*:a}
+        else
+          dir=${*:A}
+        fi
+        _zshz_add_or_remove_path --add "$dir"
         return
         ;;
       --complete)

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -845,17 +845,10 @@ _zshz_precmd() {
   # if `z -x' has just been run
   [[ $PWD == "$HOME" ]] || (( ZSHZ[DIRECTORY_REMOVED] )) && return
 
-  local dir
-  if (( ${ZSHZ_NO_RESOLVE_SYMLINKS:-${_Z_NO_RESOLVE_SYMLINKS}} )); then
-    dir="${PWD:a}"
-  else
-    dir="${PWD:A}"
-  fi
-
   # Don't track directory trees excluded in ZSHZ_EXCLUDE_DIRS
   local exclude
   for exclude in ${(@)ZSHZ_EXCLUDE_DIRS:-${(@)_Z_EXCLUDE_DIRS}}; do
-    case $dir in
+    case $PWD in
       ${exclude}|${exclude}/*) return ;;
     esac
   done
@@ -863,9 +856,9 @@ _zshz_precmd() {
   # It appears that forking a subshell is so slow in Windows that it is better
   # just to add the PWD to the datafile in the foreground
   if [[ $OSTYPE == (cygwin|msys) ]]; then
-      zshz --add "$dir"
+      zshz --add "$PWD"
   else
-      (zshz --add "$dir" &)
+      (zshz --add "$PWD" &)
   fi
 
   # See https://github.com/rupa/z/pull/247/commits/081406117ea42ccb8d159f7630cfc7658db054b6

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -664,7 +664,7 @@ zshz() {
   if [[ ${@: -1} == /* ]] && (( ! $+opts[-e] && ! $+opts[-l] )); then
     # cd if possible; echo the new path if $ZSHZ_ECHO == 1
     [[ -d ${@: -1} ]] && builtin cd ${@: -1} &&
-      (( $+ZSHZ_ECHO )) && print $PWD && return
+      (( $ZSHZ_ECHO )) && print $PWD && return || return
   fi
 
   # With option -c, make sure query string matches beginning of matches;
@@ -719,12 +719,13 @@ zshz() {
       print -- "$cd"
     else
       # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-      [[ -d $cd ]] && builtin cd "$cd" && (( $+ZSHZ_ECHO )) && print $PWD
+      [[ -d $cd ]] && builtin cd "$cd" &&
+        (( $ZSHZ_ECHO )) && print $PWD || true
     fi
   else
     # if $req is a valid path, cd to it; echo the new path if $ZSHZ_ECHO == 1
     if ! (( $+opts[-e] || $+opts[-l] )) && [[ -d $req ]]; then
-      builtin cd "$req" && (( $+ZSHZ_ECHO )) && print $PWD
+      builtin cd "$req" && (( $+ZSHZ_ECHO )) && print $PWD || true
     else
       return $ret2
     fi

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -351,6 +351,7 @@ zshz() {
 
       path_field=${line%%\|*}
 
+      path_field_normalized=$path_field
       if (( ZSHZ_TRAILING_SLASH )); then
         path_field_normalized=${path_field%/}/
       fi

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -225,11 +225,9 @@ zshz() {
         local xdir  # Directory to be removed
 
         if (( ${ZSHZ_NO_RESOLVE_SYMLINKS:-${_Z_NO_RESOLVE_SYMLINKS}} )); then
-#          [[ -d ${*:a} ]] && xdir=${*:a} || xdir=${PWD:a}
           [[ -d ${${*:-${PWD}}:a} ]] && xdir=${${*:-${PWD}}:a}
         else
           [[ -d ${${*:-${PWD}}:A} ]] && xdir=${${*:-${PWD}}:a}
-#          [[ -d ${*:A} ]] && xdir=${*:a} || xdir=${PWD:A}
         fi
 
         local -a lines_to_keep

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -234,6 +234,10 @@ zshz() {
 
         local -a lines_to_keep
         if (( ${+opts[-R]} )); then
+          # Prompt user before deleting entire database
+          if [[ $xdir == '/' ]] && ! read -q "?Delete entire ZSH-z database? "; then
+            print && return 1
+          fi
           # All of the lines that don't match the directory to be deleted
           lines_to_keep=( ${lines:#${xdir}\|*} )
           # Or its subdirectories

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -43,7 +43,8 @@
 #   * z -l foo  # List matches instead of changing directories
 #   * z -e foo  # Echo the best match without changing directories
 #   * z -c foo  # Restrict matches to subdirectories of PWD
-#   * z -x foo  # Remove the PWD from the database
+#   * z -x      # Remove PWD from the database
+#   * z -xR     # Remove PWD and its subdirectories from the database
 #
 # ENVIRONMENT VARIABLES:
 #
@@ -90,7 +91,8 @@ With no ARGUMENT, list the directory history in ascending rank.
   -l    List all matches without going to them
   -r    Match by rank
   -t    Match by recent access
-  -x    Remove the current directory from the database" | fold -s >&2
+  -x    Remove the current directory from the database
+  -xR   Remove the current directory from the database recursively" | fold -s >&2
 }
 
 # Load zsh/datetime module, if necessary

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -700,6 +700,10 @@ zshz() {
       --add)
         [[ ! -d $* ]] && return 1
         local dir
+        # Cygwin and MSYS2 have a hard time with relative paths expressed from /
+        if [[ $OSTYPE == (cygwin|msys) && $PWD == '/' && $* != /* ]]; then
+          set -- "/$*"
+        fi
         if (( ${ZSHZ_NO_RESOLVE_SYMLINKS:-${_Z_NO_RESOLVE_SYMLINKS}} )); then
           dir=${*:a}
         else
@@ -724,6 +728,10 @@ zshz() {
       -r) method='rank' ;;
       -t) method='time' ;;
       -x)
+        # Cygwin and MSYS2 have a hard time with relative paths expressed from /
+        if [[ $OSTYPE == (cygwin|msys) && $PWD == '/' && $* != /* ]]; then
+          set -- "/$*"
+        fi
         _zshz_add_or_remove_path --remove $*
         return
         ;;

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -334,7 +334,8 @@ zshz() {
       # When a rank drops below 1, drop the path from the database
       (( rank_field < 1 )) && continue
 
-      if [[ $path_field == "$1" ]]; then
+      if [[ $path_field == $add_path ]]; then
+        rank[$path_field]=$rank_field
         (( rank[$path_field]++ ))
         time[$path_field]=$now
       else

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -464,7 +464,7 @@ zshz() {
         for x in ${(k)output_matches}; do
           if (( ${output_matches[$x]} )); then
             path_to_display=$x
-            (( $+ZSHZ_TILDE )) &&
+            (( $ZSHZ_TILDE )) &&
               path_to_display=${path_to_display/#${HOME}/\~}
             _zshz_printv -f "%-10d %s\n" ${output_matches[$x]} $path_to_display
             output+=( ${(f)REPLY} )
@@ -672,7 +672,7 @@ zshz() {
   #########################################################
   _zshz_echo() {
     if (( $+ZSHZ_ECHO )); then
-      if (( $+ZSHZ_TILDE )); then
+      if (( $ZSHZ_TILDE )); then
         print ${PWD/#${HOME}/\~}
       else
         print $PWD
@@ -734,7 +734,7 @@ zshz() {
 
   if (( ret2 == 0 )) && [[ -n $cd ]]; then
     if (( $+opts[-e] )); then               # echo
-      (( $+ZSHZ_TILDE )) && cd=${cd/#${HOME}/\~}
+      (( $ZSHZ_TILDE )) && cd=${cd/#${HOME}/\~}
       print -- "$cd"
     else
       # cd if possible; echo the new path if $ZSHZ_ECHO == 1

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -342,7 +342,7 @@ zshz() {
   ############################################################
   _zshz_legacy_complete() {
 
-    local line path_field
+    local line path_field path_field_normalized
 
     # Replace spaces in the search string with asterisks for globbing
     1=${1//[[:space:]]/*}
@@ -351,11 +351,15 @@ zshz() {
 
       path_field=${line%%\|*}
 
+      if (( ZSHZ_TRAILING_SLASH )); then
+        path_field_normalized=${path_field%/}/
+      fi
+
       # If the search string is all lowercase, the search will be case-insensitive
-      if [[ $1 == "${1:l}" && ${path_field:l} == *${~1}* ]]; then
+      if [[ $1 == "${1:l}" && ${path_field_normalized:l} == *${~1}* ]]; then
         print -- $path_field
       # Otherwise, case-sensitive
-      elif [[ $path_field == *${~1}* ]]; then
+      elif [[ $path_field_normalized == *${~1}* ]]; then
         print -- $path_field
       fi
 

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -335,7 +335,7 @@ zshz() {
       (( rank_field < 1 )) && continue
 
       if [[ $path_field == "$1" ]]; then
-        rank[$path_field]=$(( rank_field + 1 ))
+        (( rank[$path_field]++ ))
         time[$path_field]=$now
       else
         rank[$path_field]=$rank_field


### PR DESCRIPTION
Ran into this on a system that ran out of space (`no space left on device`).

This PR guards against clobbering the database when a write to `tempfile` fails.